### PR TITLE
Lock to @solana/web3.js 1.x for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ module.exports = {
 
 ## Install Dependencies
 ```bash
-npm i @solana/web3.js @solana/spl-token bn.js heaven-sdk
+npm i @solana/web3.js@1 @solana/spl-token bn.js heaven-sdk
 ```
 
 ## Setup


### PR DESCRIPTION

Read why, here: https://github.com/solana-labs/solana-web3.js/issues/3498